### PR TITLE
Get checkbox and alert working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
 			"name": "sveltekit-auro",
 			"version": "0.0.1",
 			"devDependencies": {
-				"@aurodesignsystem/auro-button": "^7.2.3",
+				"@alaskaairux/icons": "^4.32.0",
+				"@aurodesignsystem/auro-alert": "^2.1.0",
+				"@aurodesignsystem/auro-checkbox": "^2.1.0",
 				"@sveltejs/adapter-auto": "^3.0.0",
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -21,76 +23,25 @@
 				"vite": "^5.0.3"
 			}
 		},
-		"node_modules/@alaskaairux/auro-loader": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@alaskaairux/auro-loader/-/auro-loader-1.1.1.tgz",
-			"integrity": "sha512-mkgFyUbVSL26R8WDDUj+lDK5NLrzkE/zQOhrleEps9ftlyhAaR1VaNIQ0jr+AYpb0DrzEo+ChIgkp778vzL1VQ==",
+		"node_modules/@alaskaairux/icons": {
+			"version": "4.32.0",
+			"resolved": "https://registry.npmjs.org/@alaskaairux/icons/-/icons-4.32.0.tgz",
+			"integrity": "sha512-SNxCxUUb7m4wpav/HF0gprlmVPM2VDswKk2fMWL9VV0fakhTOGPMZvilIj/64ehi8DuBNQyZ0GH6Kbk037LNLg==",
 			"dev": true,
 			"hasInstallScript": true,
-			"dependencies": {
-				"chalk": "^4.1.0",
-				"lit-element": "^2.4.0"
-			},
-			"peerDependencies": {
-				"@alaskaairux/design-tokens": "^3.0.0",
-				"@alaskaairux/webcorestylesheets": "^3.0.0",
-				"@webcomponents/webcomponentsjs": "^2.5.0",
-				"focus-visible": "^5.2.0"
-			}
-		},
-		"node_modules/@alaskaairux/auro-loader/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@alaskaairux/design-tokens": {
-			"version": "3.15.5",
-			"resolved": "https://registry.npmjs.org/@alaskaairux/design-tokens/-/design-tokens-3.15.5.tgz",
-			"integrity": "sha512-aS5z3uY5yJirJlja/7MiIXxFnhLLl6dIX5NmAKnpQy95VqAKbyhpvx4zv1mtMJb+y5tQ5qoo46T0SA+oAAR3Sg==",
-			"dev": true,
-			"hasInstallScript": true,
-			"peer": true,
-			"dependencies": {
-				"chalk": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@alaskaairux/webcorestylesheets": {
-			"version": "3.7.3",
-			"resolved": "https://registry.npmjs.org/@alaskaairux/webcorestylesheets/-/webcorestylesheets-3.7.3.tgz",
-			"integrity": "sha512-9JgezuqVB2j43Qwr0rDhq7+KMgQ3fIrtktJ6QsQr6zgOweufQVSdUU9sdLQeNCZg94iS9rw2GOl2+oJ6yPJpwQ==",
-			"deprecated": "Web core stylesheets with the @alaskaairux namespace is no longer supported. Please update to the new @aurodesignsystem/webcorestylesheets @4.0 to be current with all new changes",
-			"dev": true,
-			"hasInstallScript": true,
-			"peer": true,
 			"dependencies": {
 				"chalk": "^4.1.2",
-				"focus-visible": "^5.1.0"
+				"svgo": "^3.0.2"
 			},
-			"peerDependencies": {
-				"@alaskaairux/design-tokens": "^3.0.0",
-				"sass": "^1.42.1"
+			"engines": {
+				"node": ">=18.17.1"
 			}
 		},
-		"node_modules/@alaskaairux/webcorestylesheets/node_modules/chalk": {
+		"node_modules/@alaskaairux/icons/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -115,14 +66,34 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@aurodesignsystem/auro-button": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-button/-/auro-button-7.2.3.tgz",
-			"integrity": "sha512-ti0vPfvp54ohGM4jNFjYeRXhyU4QDbMW5ArFaMnJvhi3c0MqCvWZjHqbB8nmHkPRPwIEehdGxpJixLGHX2lU+Q==",
+		"node_modules/@aurodesignsystem/auro-alert": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-alert/-/auro-alert-2.1.0.tgz",
+			"integrity": "sha512-XmS+D+wEPxAFuBEFj6EzkAsiTfsONPj4F1mntSinWXNyqrgHtC1/jTdbVSQkuP+etN4eECbb19pCUDNtXXECMA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@alaskaairux/auro-loader": "^1.1.1",
+				"chalk": "^5.2.0",
+				"lit": "^3.1.1",
+				"typescript": "^5.3.3"
+			},
+			"engines": {
+				"node": "^18 || ^20"
+			},
+			"peerDependencies": {
+				"@alaskaairux/icons": "^4.28.0",
+				"@aurodesignsystem/design-tokens": "^4.1.1",
+				"@aurodesignsystem/webcorestylesheets": "^5.0.4"
+			}
+		},
+		"node_modules/@aurodesignsystem/auro-checkbox": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-checkbox/-/auro-checkbox-2.1.0.tgz",
+			"integrity": "sha512-f3ZDTF+Jk+CJ5P10Wf3SYN4K6gSPLF/2SF/E+13ot/OiaB32mGVgwV5eiip7M2BcmJLjkdtnI8/MNznAaF5/0Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"dependencies": {
+				"@alaskaairux/icons": "^4.31.0",
 				"chalk": "^5.3.0",
 				"lit": "^3.1.1"
 			},
@@ -131,7 +102,7 @@
 			},
 			"peerDependencies": {
 				"@aurodesignsystem/design-tokens": "^4.1.1",
-				"@aurodesignsystem/webcorestylesheets": "^5.0.0"
+				"@aurodesignsystem/webcorestylesheets": "^5.0.5"
 			}
 		},
 		"node_modules/@aurodesignsystem/design-tokens": {
@@ -573,9 +544,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.20",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+			"version": "0.3.22",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+			"integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -639,9 +610,9 @@
 			"dev": true
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.4.tgz",
-			"integrity": "sha512-ub/SN3yWqIv5CWiAZPHVS1DloyZsJbtXmX4HxUTIpS0BHm9pW5iYBo2mIZi+hE3AeiTzHz33blwSnhdUo+9NpA==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.9.5.tgz",
+			"integrity": "sha512-idWaG8xeSRCfRq9KpRysDHJ/rEHBEXcHuJ82XY0yYFIWnLMjZv9vF/7DOq8djQ2n3Lk6+3qfSH8AqlmHlmi1MA==",
 			"cpu": [
 				"arm"
 			],
@@ -652,9 +623,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-android-arm64": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.4.tgz",
-			"integrity": "sha512-ehcBrOR5XTl0W0t2WxfTyHCR/3Cq2jfb+I4W+Ch8Y9b5G+vbAecVv0Fx/J1QKktOrgUYsIKxWAKgIpvw56IFNA==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.9.5.tgz",
+			"integrity": "sha512-f14d7uhAMtsCGjAYwZGv6TwuS3IFaM4ZnGMUn3aCBgkcHAYErhV1Ad97WzBvS2o0aaDv4mVz+syiN0ElMyfBPg==",
 			"cpu": [
 				"arm64"
 			],
@@ -665,9 +636,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-arm64": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.4.tgz",
-			"integrity": "sha512-1fzh1lWExwSTWy8vJPnNbNM02WZDS8AW3McEOb7wW+nPChLKf3WG2aG7fhaUmfX5FKw9zhsF5+MBwArGyNM7NA==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.9.5.tgz",
+			"integrity": "sha512-ndoXeLx455FffL68OIUrVr89Xu1WLzAG4n65R8roDlCoYiQcGGg6MALvs2Ap9zs7AHg8mpHtMpwC8jBBjZrT/w==",
 			"cpu": [
 				"arm64"
 			],
@@ -678,9 +649,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-darwin-x64": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.4.tgz",
-			"integrity": "sha512-Gc6cukkF38RcYQ6uPdiXi70JB0f29CwcQ7+r4QpfNpQFVHXRd0DfWFidoGxjSx1DwOETM97JPz1RXL5ISSB0pA==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.9.5.tgz",
+			"integrity": "sha512-UmElV1OY2m/1KEEqTlIjieKfVwRg0Zwg4PLgNf0s3glAHXBN99KLpw5A5lrSYCa1Kp63czTpVll2MAqbZYIHoA==",
 			"cpu": [
 				"x64"
 			],
@@ -691,9 +662,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.4.tgz",
-			"integrity": "sha512-g21RTeFzoTl8GxosHbnQZ0/JkuFIB13C3T7Y0HtKzOXmoHhewLbVTFBQZu+z5m9STH6FZ7L/oPgU4Nm5ErN2fw==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.9.5.tgz",
+			"integrity": "sha512-Q0LcU61v92tQB6ae+udZvOyZ0wfpGojtAKrrpAaIqmJ7+psq4cMIhT/9lfV6UQIpeItnq/2QDROhNLo00lOD1g==",
 			"cpu": [
 				"arm"
 			],
@@ -704,9 +675,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-gnu": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.4.tgz",
-			"integrity": "sha512-TVYVWD/SYwWzGGnbfTkrNpdE4HON46orgMNHCivlXmlsSGQOx/OHHYiQcMIOx38/GWgwr/po2LBn7wypkWw/Mg==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.9.5.tgz",
+			"integrity": "sha512-dkRscpM+RrR2Ee3eOQmRWFjmV/payHEOrjyq1VZegRUa5OrZJ2MAxBNs05bZuY0YCtpqETDy1Ix4i/hRqX98cA==",
 			"cpu": [
 				"arm64"
 			],
@@ -717,9 +688,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-arm64-musl": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.4.tgz",
-			"integrity": "sha512-XcKvuendwizYYhFxpvQ3xVpzje2HHImzg33wL9zvxtj77HvPStbSGI9czrdbfrf8DGMcNNReH9pVZv8qejAQ5A==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.9.5.tgz",
+			"integrity": "sha512-QaKFVOzzST2xzY4MAmiDmURagWLFh+zZtttuEnuNn19AiZ0T3fhPyjPPGwLNdiDT82ZE91hnfJsUiDwF9DClIQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -730,9 +701,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-riscv64-gnu": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.4.tgz",
-			"integrity": "sha512-LFHS/8Q+I9YA0yVETyjonMJ3UA+DczeBd/MqNEzsGSTdNvSJa1OJZcSH8GiXLvcizgp9AlHs2walqRcqzjOi3A==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.9.5.tgz",
+			"integrity": "sha512-HeGqmRJuyVg6/X6MpE2ur7GbymBPS8Np0S/vQFHDmocfORT+Zt76qu+69NUoxXzGqVP1pzaY6QIi0FJWLC3OPA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -743,9 +714,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.4.tgz",
-			"integrity": "sha512-dIYgo+j1+yfy81i0YVU5KnQrIJZE8ERomx17ReU4GREjGtDW4X+nvkBak2xAUpyqLs4eleDSj3RrV72fQos7zw==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
+			"integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
 			"cpu": [
 				"x64"
 			],
@@ -756,9 +727,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-musl": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.4.tgz",
-			"integrity": "sha512-RoaYxjdHQ5TPjaPrLsfKqR3pakMr3JGqZ+jZM0zP2IkDtsGa4CqYaWSfQmZVgFUCgLrTnzX+cnHS3nfl+kB6ZQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.9.5.tgz",
+			"integrity": "sha512-ezyFUOwldYpj7AbkwyW9AJ203peub81CaAIVvckdkyH8EvhEIoKzaMFJj0G4qYJ5sw3BpqhFrsCc30t54HV8vg==",
 			"cpu": [
 				"x64"
 			],
@@ -769,9 +740,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-arm64-msvc": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.4.tgz",
-			"integrity": "sha512-T8Q3XHV+Jjf5e49B4EAaLKV74BbX7/qYBRQ8Wop/+TyyU0k+vSjiLVSHNWdVd1goMjZcbhDmYZUYW5RFqkBNHQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.9.5.tgz",
+			"integrity": "sha512-aHSsMnUw+0UETB0Hlv7B/ZHOGY5bQdwMKJSzGfDfvyhnpmVxLMGnQPGNE9wgqkLUs3+gbG1Qx02S2LLfJ5GaRQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -782,9 +753,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-ia32-msvc": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.4.tgz",
-			"integrity": "sha512-z+JQ7JirDUHAsMecVydnBPWLwJjbppU+7LZjffGf+Jvrxq+dVjIE7By163Sc9DKc3ADSU50qPVw0KonBS+a+HQ==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.9.5.tgz",
+			"integrity": "sha512-AiqiLkb9KSf7Lj/o1U3SEP9Zn+5NuVKgFdRIZkvd4N0+bYrTOovVd0+LmYCPQGbocT4kvFyK+LXCDiXPBF3fyA==",
 			"cpu": [
 				"ia32"
 			],
@@ -795,9 +766,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.4.tgz",
-			"integrity": "sha512-LfdGXCV9rdEify1oxlN9eamvDSjv9md9ZVMAbNHA87xqIfFCxImxan9qZ8+Un54iK2nnqPlbnSi4R54ONtbWBw==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.9.5.tgz",
+			"integrity": "sha512-1q+mykKE3Vot1kaFJIDoUFv5TuW+QQVaf2FmTT9krg86pQrGStOSJJ0Zil7CFagyxDuouTepzt5Y5TVzyajOdQ==",
 			"cpu": [
 				"x64"
 			],
@@ -808,9 +779,9 @@
 			]
 		},
 		"node_modules/@sveltejs/adapter-auto": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.1.0.tgz",
-			"integrity": "sha512-igS5hqCwdiXWb8NoWzThKCVQQj9tKgUkbTtzfxBPgSLOyFjkiGNDX0SgCoY2QIUWBqOkfGTOqGlrW5Ynw9oUvw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/adapter-auto/-/adapter-auto-3.1.1.tgz",
+			"integrity": "sha512-6LeZft2Fo/4HfmLBi5CucMYmgRxgcETweQl/yQoZo/895K3S9YWYN4Sfm/IhwlIpbJp3QNvhKmwCHbsqQNYQpw==",
 			"dev": true,
 			"dependencies": {
 				"import-meta-resolve": "^4.0.0"
@@ -820,9 +791,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.3.2.tgz",
-			"integrity": "sha512-AzGWV1TyUSkBuciy06E5NegXndIEgTthDtllv80qynEJFh8bZD62ZxLajiQLOsKGqRDilEQyshDARQxjIqiaqg==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.4.1.tgz",
+			"integrity": "sha512-NnDrPOmTjzhgWkwJNPcth3vBMWQmI/QhwbMRXow1p/RkM+17HxP2yQR3GYwIK83rkYSKwQiweyBVWGOjJY4gsg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -890,6 +861,15 @@
 				"vite": "^5.0.0"
 			}
 		},
+		"node_modules/@trysound/sax": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+			"integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.13.0"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -913,13 +893,6 @@
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
 			"dev": true
-		},
-		"node_modules/@webcomponents/webcomponentsjs": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.8.0.tgz",
-			"integrity": "sha512-loGD63sacRzOzSJgQnB9ZAhaQGkN7wl2Zuw7tsphI5Isa0irijrRo6EnJii/GgjGefIFO8AIO7UivzRhFaEk9w==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/acorn": {
 			"version": "8.11.3",
@@ -971,9 +944,9 @@
 			}
 		},
 		"node_modules/axobject-query": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
-			"integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.0.0.tgz",
+			"integrity": "sha512-+60uv1hiVFhHZeO+Lz0RYzsVHy5Wr1ayX0mwda9KPDVLNJgZ1T9Ny7VmFbLDzxsH0D87I86vgj3gFrjTJUYznw==",
 			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
@@ -993,6 +966,12 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/boolbase": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+			"integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+			"dev": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -1104,6 +1083,15 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
+		"node_modules/commander": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+			"integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1119,6 +1107,22 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
 		"node_modules/css-tree": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -1131,6 +1135,51 @@
 			"engines": {
 				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
 			}
+		},
+		"node_modules/css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"dev": true,
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/csso": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+			"integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+			"dev": true,
+			"dependencies": {
+				"css-tree": "~2.2.0"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/csso/node_modules/css-tree": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+			"integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+			"dev": true,
+			"dependencies": {
+				"mdn-data": "2.0.28",
+				"source-map-js": "^1.0.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
+		"node_modules/csso/node_modules/mdn-data": {
+			"version": "2.0.28",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+			"integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+			"dev": true
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -1181,6 +1230,73 @@
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-4.3.2.tgz",
 			"integrity": "sha512-KqFl6pOgOW+Y6wJgu80rHpo2/3H07vr8ntR9rkkFIRETewbf5GaYYcakYfiKz89K+sLsuPkQIZaXDMjUObZwWg==",
 			"dev": true
+		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			]
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"dev": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
 		},
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
@@ -1277,13 +1393,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/focus-visible": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
-			"integrity": "sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
@@ -1485,30 +1594,6 @@
 			}
 		},
 		"node_modules/lit-element": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.5.1.tgz",
-			"integrity": "sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==",
-			"dev": true,
-			"dependencies": {
-				"lit-html": "^1.1.1"
-			}
-		},
-		"node_modules/lit-element/node_modules/lit-html": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz",
-			"integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==",
-			"dev": true
-		},
-		"node_modules/lit-html": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.1.tgz",
-			"integrity": "sha512-x/EwfGk2D/f4odSFM40hcGumzqoKv0/SUh6fBO+1Ragez81APrcAMPo1jIrCDd9Sn+Z4CT867HWKViByvkDZUA==",
-			"dev": true,
-			"dependencies": {
-				"@types/trusted-types": "^2.0.2"
-			}
-		},
-		"node_modules/lit/node_modules/lit-element": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.3.tgz",
 			"integrity": "sha512-2vhidmC7gGLfnVx41P8UZpzyS0Fb8wYhS5RCm16cMW3oERO0Khd3EsKwtRpOnttuByI5rURjT2dfoA7NlInCNw==",
@@ -1517,6 +1602,15 @@
 				"@lit-labs/ssr-dom-shim": "^1.1.2",
 				"@lit/reactive-element": "^2.0.0",
 				"lit-html": "^3.1.0"
+			}
+		},
+		"node_modules/lit-html": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.1.tgz",
+			"integrity": "sha512-x/EwfGk2D/f4odSFM40hcGumzqoKv0/SUh6fBO+1Ragez81APrcAMPo1jIrCDd9Sn+Z4CT867HWKViByvkDZUA==",
+			"dev": true,
+			"dependencies": {
+				"@types/trusted-types": "^2.0.2"
 			}
 		},
 		"node_modules/locate-character": {
@@ -1658,6 +1752,18 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
+		},
 		"node_modules/once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1746,9 +1852,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-			"integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
+			"integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -1834,9 +1940,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "4.9.4",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.4.tgz",
-			"integrity": "sha512-2ztU7pY/lrQyXSCnnoU4ICjT/tCG9cdH3/G25ERqE3Lst6vl2BCM5hL2Nw+sslAvAf+ccKsAq1SkKQALyqhR7g==",
+			"version": "4.9.5",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.9.5.tgz",
+			"integrity": "sha512-E4vQW0H/mbNMw2yLSqJyjtkHY9dslf/p0zuT1xehNRqUTBOFMqEjguDvqhXr7N7r/4ttb2jr4T41d3dncmIgbQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/estree": "1.0.5"
@@ -1849,19 +1955,19 @@
 				"npm": ">=8.0.0"
 			},
 			"optionalDependencies": {
-				"@rollup/rollup-android-arm-eabi": "4.9.4",
-				"@rollup/rollup-android-arm64": "4.9.4",
-				"@rollup/rollup-darwin-arm64": "4.9.4",
-				"@rollup/rollup-darwin-x64": "4.9.4",
-				"@rollup/rollup-linux-arm-gnueabihf": "4.9.4",
-				"@rollup/rollup-linux-arm64-gnu": "4.9.4",
-				"@rollup/rollup-linux-arm64-musl": "4.9.4",
-				"@rollup/rollup-linux-riscv64-gnu": "4.9.4",
-				"@rollup/rollup-linux-x64-gnu": "4.9.4",
-				"@rollup/rollup-linux-x64-musl": "4.9.4",
-				"@rollup/rollup-win32-arm64-msvc": "4.9.4",
-				"@rollup/rollup-win32-ia32-msvc": "4.9.4",
-				"@rollup/rollup-win32-x64-msvc": "4.9.4",
+				"@rollup/rollup-android-arm-eabi": "4.9.5",
+				"@rollup/rollup-android-arm64": "4.9.5",
+				"@rollup/rollup-darwin-arm64": "4.9.5",
+				"@rollup/rollup-darwin-x64": "4.9.5",
+				"@rollup/rollup-linux-arm-gnueabihf": "4.9.5",
+				"@rollup/rollup-linux-arm64-gnu": "4.9.5",
+				"@rollup/rollup-linux-arm64-musl": "4.9.5",
+				"@rollup/rollup-linux-riscv64-gnu": "4.9.5",
+				"@rollup/rollup-linux-x64-gnu": "4.9.5",
+				"@rollup/rollup-linux-x64-musl": "4.9.5",
+				"@rollup/rollup-win32-arm64-msvc": "4.9.5",
+				"@rollup/rollup-win32-ia32-msvc": "4.9.5",
+				"@rollup/rollup-win32-x64-msvc": "4.9.5",
 				"fsevents": "~2.3.2"
 			}
 		},
@@ -1913,9 +2019,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.69.7",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.69.7.tgz",
-			"integrity": "sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==",
+			"version": "1.70.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.70.0.tgz",
+			"integrity": "sha512-uUxNQ3zAHeAx5nRFskBnrWzDUJrrvpCPD5FNAoRvTi0WwremlheES3tg+56PaVtCs5QDRX5CBLxxKMDJMEa1WQ==",
 			"dev": true,
 			"peer": true,
 			"dependencies": {
@@ -1999,17 +2105,18 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.8.tgz",
-			"integrity": "sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==",
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.9.tgz",
+			"integrity": "sha512-hsoB/WZGEPFXeRRLPhPrbRz67PhP6sqYgvwcAs+gWdSQSvNDw+/lTeUJSWe5h2xC97Fz/8QxAOqItwBzNJPU8w==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
 				"@jridgewell/trace-mapping": "^0.3.18",
+				"@types/estree": "^1.0.1",
 				"acorn": "^8.9.0",
 				"aria-query": "^5.3.0",
-				"axobject-query": "^3.2.1",
+				"axobject-query": "^4.0.0",
 				"code-red": "^1.0.3",
 				"css-tree": "^2.3.1",
 				"estree-walker": "^3.0.3",
@@ -2023,9 +2130,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.2.tgz",
-			"integrity": "sha512-E6iFh4aUCGJLRz6QZXH3gcN/VFfkzwtruWSRmlKrLWQTiO6VzLsivR6q02WYLGNAGecV3EocqZuCDrC2uttZ0g==",
+			"version": "3.6.3",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-3.6.3.tgz",
+			"integrity": "sha512-Q2nGnoysxUnB9KjnjpQLZwdjK62DHyW6nuH/gm2qteFnDk0lCehe/6z8TsIvYeKjC6luKaWxiNGyOcWiLLPSwA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.17",
@@ -2119,6 +2226,31 @@
 				}
 			}
 		},
+		"node_modules/svgo": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+			"integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
+			"dev": true,
+			"dependencies": {
+				"@trysound/sax": "0.2.0",
+				"commander": "^7.2.0",
+				"css-select": "^5.1.0",
+				"css-tree": "^2.3.1",
+				"css-what": "^6.1.0",
+				"csso": "^5.0.5",
+				"picocolors": "^1.0.0"
+			},
+			"bin": {
+				"svgo": "bin/svgo"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/svgo"
+			}
+		},
 		"node_modules/tiny-glob": {
 			"version": "0.2.9",
 			"resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
@@ -2170,9 +2302,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "5.0.11",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-5.0.11.tgz",
-			"integrity": "sha512-XBMnDjZcNAw/G1gEiskiM1v6yzM4GE5aMGvhWTlHAYYhxb7S3/V1s3m2LDHa8Vh6yIWYYB0iJwsEaS523c4oYA==",
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-5.0.12.tgz",
+			"integrity": "sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.19.3",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
 		"format": "prettier --write ."
 	},
 	"devDependencies": {
-		"@aurodesignsystem/auro-button": "^7.2.3",
+		"@alaskaairux/icons": "^4.32.0",
+		"@aurodesignsystem/auro-alert": "^2.1.0",
+		"@aurodesignsystem/auro-checkbox": "^2.1.0",
 		"@sveltejs/adapter-auto": "^3.0.0",
 		"@sveltejs/kit": "^2.0.0",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,7 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@aurodesignsystem/design-tokens@latest/dist/tokens/CSSCustomProperties.css">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,23 +1,23 @@
 <script>
-	import { onMount } from 'svelte';
-	// this custom element is safe to import on server & client
-	// it uses a newer version of lit that doesn't reference `window` at the top level of a script
 	import './test-component';
-	import('@aurodesignsystem/auro-alert');
-	onMount(() => {
-		// this component relies on an old version of lit that references `window` directly
-		// we need to import it inside `onMount`, so that it's only imported on the client (where window is available)
-		import('@aurodesignsystem/auro-checkbox');
-		// import('@aurodesignsystem/auro-alert');
-	});
+	import '@aurodesignsystem/auro-alert';
+	import '@aurodesignsystem/auro-checkbox';
 </script>
 
 <auro-alert type="error">Transaction failed.</auro-alert>
 
 <auro-checkbox-group>
-  <span slot="legend">Form label goes here</span>
-  <auro-checkbox value="checkbox option" name="example1" id="checkbox-basic1">Checkbox option</auro-checkbox>
-  <auro-checkbox value="checkbox option" name="example2" id="checkbox-basic2" checked>Checkbox option</auro-checkbox>
-  <auro-checkbox value="checkbox option" name="example3" id="checkbox-basic3">Checkbox option</auro-checkbox>
-  <auro-checkbox value="checkbox option" name="example4" id="checkbox-basic4">Checkbox option</auro-checkbox>
+	<span slot="legend">Form label goes here</span>
+	<auro-checkbox value="checkbox option" name="example1" id="checkbox-basic1"
+		>Checkbox option</auro-checkbox
+	>
+	<auro-checkbox value="checkbox option" name="example2" id="checkbox-basic2" checked
+		>Checkbox option</auro-checkbox
+	>
+	<auro-checkbox value="checkbox option" name="example3" id="checkbox-basic3"
+		>Checkbox option</auro-checkbox
+	>
+	<auro-checkbox value="checkbox option" name="example4" id="checkbox-basic4"
+		>Checkbox option</auro-checkbox
+	>
 </auro-checkbox-group>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,12 +3,21 @@
 	// this custom element is safe to import on server & client
 	// it uses a newer version of lit that doesn't reference `window` at the top level of a script
 	import './test-component';
+	import('@aurodesignsystem/auro-alert');
 	onMount(() => {
 		// this component relies on an old version of lit that references `window` directly
 		// we need to import it inside `onMount`, so that it's only imported on the client (where window is available)
-		import('@aurodesignsystem/auro-button');
+		import('@aurodesignsystem/auro-checkbox');
+		// import('@aurodesignsystem/auro-alert');
 	});
 </script>
 
-<auro-button>Hello World</auro-button>
-<simple-greeting></simple-greeting>
+<auro-alert type="error">Transaction failed.</auro-alert>
+
+<auro-checkbox-group>
+  <span slot="legend">Form label goes here</span>
+  <auro-checkbox value="checkbox option" name="example1" id="checkbox-basic1">Checkbox option</auro-checkbox>
+  <auro-checkbox value="checkbox option" name="example2" id="checkbox-basic2" checked>Checkbox option</auro-checkbox>
+  <auro-checkbox value="checkbox option" name="example3" id="checkbox-basic3">Checkbox option</auro-checkbox>
+  <auro-checkbox value="checkbox option" name="example4" id="checkbox-basic4">Checkbox option</auro-checkbox>
+</auro-checkbox-group>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,13 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	ssr: {
+		noExternal: [
+			'@aurodesignsystem/auro-alert',
+			'@aurodesignsystem/webcorestylesheets',
+			'@alaskaairux/icons',
+			'@aurodesignsystem/auro-checkbox'
+		]
+	}
 });


### PR DESCRIPTION
This PR adds auro-alert and auro-checkbox.

Originally, adding this imports caused an error when running `npm run dev`:

> Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/Users/grich/code/throwaway/sveltekit-auro/node_modules/@aurodesignsystem/auro-alert/src/auro-alert' imported from /Users/grich/code/throwaway/sveltekit-auro/node_modules/@aurodesignsystem/auro-alert/index.js

This is because by adding the import in a `+page.svelte` file, it will be imported on the server (as well as the client). This means the following line was run in a Node server:

```js
import '@aurodesignsystem/auro-alert';
```

This caused Node to import and run `node_modules/@aurodesignsystem/auro-alert/index.js`. However, that file contained invalid code in Node.js, which [requires extensions on imports](https://nodejs.org/api/esm.html#mandatory-file-extensions):

```js
import { AuroAlert } from './src/auro-alert'; // invalid in a Node server, needs to be auro-alert.js
```

We can fix this in one of two ways:
1. Update the package to always import with explicit `.js` file extensions. This is a [Lit best practice](https://lit.dev/docs/tools/publishing/#include-file-extensions-in-import-specifiers) anyway, so is worth doing. However, it will take time. The short term fix is to...
2. Set all erroring Auro dependencies as [ssr.noExternal](https://vitejs.dev/config/ssr-options.html#ssr-noexternal) in our Vite config. Vite is SvelteKit's build tool. By marking dependencies as `noExternal`, they will be bundled into the final server code instead of imported at runtime. This means the invalid import without a file extension is no longer an issue.

https://github.com/geoffrich/sveltekit-auro/blob/4ccdb3cb78d5422e0ad12e523f119d36ec24cdf5/vite.config.ts#L7-L12
